### PR TITLE
Improve Kuudra direction detection reliability and add 4s widget display

### DIFF
--- a/src/client/java/net/iqaddons/mod/events/dispatcher/detector/DirectionDetector.java
+++ b/src/client/java/net/iqaddons/mod/events/dispatcher/detector/DirectionDetector.java
@@ -5,6 +5,7 @@ import net.iqaddons.mod.events.Event;
 import net.iqaddons.mod.events.impl.ClientTickEvent;
 import net.iqaddons.mod.events.impl.skyblock.KuudraDirectionChangeEvent;
 import net.iqaddons.mod.model.kuudra.KuudraContext;
+import net.iqaddons.mod.model.kuudra.KuudraPhase;
 import net.iqaddons.mod.utils.KuudraLocationUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -20,10 +21,17 @@ public class DirectionDetector {
     public void detect(@NotNull ClientTickEvent event, KuudraContext context, Consumer<Event> postEvent) {
         if (!event.isInGame()) return;
 
-        var bossInfo = context.bossInfo();
-        if (!bossInfo.isAlive()) return;
+        var phase = context.phase();
+        if (phase != KuudraPhase.SKIP && phase != KuudraPhase.BOSS) return;
 
-        var direction = KuudraLocationUtil.getDirection(bossInfo.bossEntity());
+        var bossInfo = context.bossInfo();
+        var kuudraEntity = bossInfo.isAlive()
+                ? bossInfo.bossEntity()
+                : KuudraLocationUtil.findKuudra().orElse(null);
+
+        if (kuudraEntity == null || !kuudraEntity.isAlive()) return;
+
+        var direction = KuudraLocationUtil.getDirection(kuudraEntity);
         if (direction != UNKNOWN && direction != currentDirection) {
             postEvent.accept(new KuudraDirectionChangeEvent(
                     currentDirection,

--- a/src/client/java/net/iqaddons/mod/features/widgets/KuudraDirectionWidget.java
+++ b/src/client/java/net/iqaddons/mod/features/widgets/KuudraDirectionWidget.java
@@ -6,6 +6,7 @@ import net.iqaddons.mod.events.impl.skyblock.KuudraDirectionChangeEvent;
 import net.iqaddons.mod.hud.component.HudLine;
 import net.iqaddons.mod.hud.element.HudAnchor;
 import net.iqaddons.mod.hud.element.HudWidget;
+import net.iqaddons.mod.events.impl.ClientTickEvent;
 import net.iqaddons.mod.manager.KuudraStateManager;
 import net.iqaddons.mod.model.kuudra.KuudraPhase;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +14,11 @@ import org.jetbrains.annotations.NotNull;
 @Slf4j
 public class KuudraDirectionWidget extends HudWidget {
 
-    private final HudLine directionLine = HudLine.of("§a§lFRONT");
+    private static final int DISPLAY_TICKS = 80;
+
+    private int directionTicksRemaining = 0;
+    private final HudLine directionLine = HudLine.of("§a§lFRONT")
+            .showWhen(() -> directionTicksRemaining > 0);
 
     public KuudraDirectionWidget() {
         super("kuudra_direction",
@@ -27,7 +32,7 @@ public class KuudraDirectionWidget extends HudWidget {
         setEnabledSupplier(() -> PhaseFourConfig.kuudraDirectionAlert);
         setVisibilityCondition(() -> {
             var phase = KuudraStateManager.get().phase();
-            return phase == KuudraPhase.BOSS;
+            return phase == KuudraPhase.SKIP || phase == KuudraPhase.BOSS;
         });
 
         setExampleLines(HudLine.of("§a§lFRONT"));
@@ -35,16 +40,36 @@ public class KuudraDirectionWidget extends HudWidget {
 
     @Override
     protected void onActivate() {
+        directionTicksRemaining = 0;
+
         clearLines();
         addLines(directionLine);
 
         subscribe(KuudraDirectionChangeEvent.class, this::onDirectionChange);
+        subscribe(ClientTickEvent.class, this::onTick);
+    }
+
+    @Override
+    protected void onDeactivate() {
+        directionTicksRemaining = 0;
     }
 
     private void onDirectionChange(@NotNull KuudraDirectionChangeEvent event) {
         var newDirection = event.newDirection();
 
         directionLine.text(newDirection.getFormattedName());
+        directionTicksRemaining = DISPLAY_TICKS;
         markDimensionsDirty();
+    }
+
+    private void onTick(@NotNull ClientTickEvent event) {
+        if (!event.isInGame()) return;
+
+        if (directionTicksRemaining > 0) {
+            directionTicksRemaining--;
+            if (directionTicksRemaining == 0) {
+                markDimensionsDirty();
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Players reported intermittent failures where the Kuudra spawn side widget sometimes did not show during Skip/Boss transitions, likely because detection relied strictly on a live `bossInfo` that can be stale across ticks.
- The widget should appear during `SKIP` and `BOSS` and display the detected side for approximately 4 seconds (80 ticks) each time the side is determined.

### Description
- Restrict `DirectionDetector.detect` to only run during `KuudraPhase.SKIP` and `KuudraPhase.BOSS` to avoid out-of-context detections. (`DirectionDetector.java`)
- Add a fallback lookup using `KuudraLocationUtil.findKuudra()` when `context.bossInfo()` is not alive, and derive the direction from the resolved entity. (`DirectionDetector.java`)
- Update `KuudraDirectionWidget` to be visible in both `SKIP` and `BOSS`, subscribe to `ClientTickEvent` and display the latest direction text for 80 ticks (4s) using an internal tick counter that auto-hides the line when the timer expires. (`KuudraDirectionWidget.java`)
- Preserve prior behavior of only posting a `KuudraDirectionChangeEvent` when the direction is known and different from the last reported direction. (`DirectionDetector.java`)

### Testing
- Attempted to compile with `bash ./gradlew compileJava` to validate integration, but the build failed to start because the Gradle wrapper download is blocked in this environment (proxy returned `403 Forbidden`).
- Static verification performed via `git diff`/inspection and local file edits; no unit tests exist for this flow so no automated test suite passed here due to environment constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c0ea39c20832a8551b110ce3e1d5a)