### PR TITLE
Stabilize Kuudra direction detection and add timed direction widget display

### DIFF
--- a/src/client/java/net/iqaddons/mod/events/dispatcher/detector/DirectionDetector.java
+++ b/src/client/java/net/iqaddons/mod/events/dispatcher/detector/DirectionDetector.java
@@ -5,6 +5,7 @@ import net.iqaddons.mod.events.Event;
 import net.iqaddons.mod.events.impl.ClientTickEvent;
 import net.iqaddons.mod.events.impl.skyblock.KuudraDirectionChangeEvent;
 import net.iqaddons.mod.model.kuudra.KuudraContext;
+import net.iqaddons.mod.model.kuudra.KuudraPhase;
 import net.iqaddons.mod.utils.KuudraLocationUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -15,27 +16,78 @@ import static net.iqaddons.mod.utils.KuudraLocationUtil.SpawnDirection.UNKNOWN;
 @Slf4j
 public class DirectionDetector {
 
+    private static final int DIRECTION_CONFIRM_TICKS = 4;
+    private static final int DIRECTION_EVENT_COOLDOWN_TICKS = 20;
+
     private volatile KuudraLocationUtil.SpawnDirection currentDirection = UNKNOWN;
+    private volatile KuudraLocationUtil.SpawnDirection candidateDirection = UNKNOWN;
+
+    private volatile long candidateStartTick = -1;
+    private volatile long lastDirectionEventTick = -1;
 
     public void detect(@NotNull ClientTickEvent event, KuudraContext context, Consumer<Event> postEvent) {
         if (!event.isInGame()) return;
 
+        var phase = context.phase();
+        if (phase != KuudraPhase.SKIP && phase != KuudraPhase.BOSS) return;
+
         var bossInfo = context.bossInfo();
-        if (!bossInfo.isAlive()) return;
+        var kuudraEntity = bossInfo.isAlive()
+                ? bossInfo.bossEntity()
+                : KuudraLocationUtil.findKuudra().orElse(null);
 
-        var direction = KuudraLocationUtil.getDirection(bossInfo.bossEntity());
-        if (direction != UNKNOWN && direction != currentDirection) {
-            postEvent.accept(new KuudraDirectionChangeEvent(
-                    currentDirection,
-                    direction
-            ));
-
-            currentDirection = direction;
-            log.info("Kuudra direction changed: {}", direction);
+        if (kuudraEntity == null || !kuudraEntity.isAlive()) {
+            clearCandidate();
+            return;
         }
+
+        var rawDirection = KuudraLocationUtil.getDirection(kuudraEntity);
+        if (rawDirection == UNKNOWN) {
+            clearCandidate();
+            return;
+        }
+
+        long tick = event.tickCount();
+        if (rawDirection != candidateDirection) {
+            candidateDirection = rawDirection;
+            candidateStartTick = tick;
+            return;
+        }
+
+        if (!isCandidateStable(tick)) return;
+        if (candidateDirection == currentDirection) return;
+        if (!isOutsideCooldown(tick)) return;
+
+        var previousDirection = currentDirection;
+        currentDirection = candidateDirection;
+        lastDirectionEventTick = tick;
+
+        postEvent.accept(new KuudraDirectionChangeEvent(
+                previousDirection,
+                currentDirection
+        ));
+
+        log.info("Kuudra direction changed: {}", currentDirection);
     }
 
     public void reset() {
         currentDirection = UNKNOWN;
+        clearCandidate();
+        lastDirectionEventTick = -1;
+    }
+
+    private boolean isCandidateStable(long currentTick) {
+        return candidateStartTick >= 0
+                && (currentTick - candidateStartTick + 1) >= DIRECTION_CONFIRM_TICKS;
+    }
+
+    private boolean isOutsideCooldown(long currentTick) {
+        return lastDirectionEventTick < 0
+                || (currentTick - lastDirectionEventTick) >= DIRECTION_EVENT_COOLDOWN_TICKS;
+    }
+
+    private void clearCandidate() {
+        candidateDirection = UNKNOWN;
+        candidateStartTick = -1;
     }
 }

--- a/src/client/java/net/iqaddons/mod/features/widgets/KuudraDirectionWidget.java
+++ b/src/client/java/net/iqaddons/mod/features/widgets/KuudraDirectionWidget.java
@@ -6,6 +6,7 @@ import net.iqaddons.mod.events.impl.skyblock.KuudraDirectionChangeEvent;
 import net.iqaddons.mod.hud.component.HudLine;
 import net.iqaddons.mod.hud.element.HudAnchor;
 import net.iqaddons.mod.hud.element.HudWidget;
+import net.iqaddons.mod.events.impl.ClientTickEvent;
 import net.iqaddons.mod.manager.KuudraStateManager;
 import net.iqaddons.mod.model.kuudra.KuudraPhase;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +14,11 @@ import org.jetbrains.annotations.NotNull;
 @Slf4j
 public class KuudraDirectionWidget extends HudWidget {
 
-    private final HudLine directionLine = HudLine.of("§a§lFRONT");
+    private static final int DISPLAY_TICKS = 80;
+
+    private int directionTicksRemaining = 0;
+    private final HudLine directionLine = HudLine.of("§a§lFRONT")
+            .showWhen(() -> directionTicksRemaining > 0);
 
     public KuudraDirectionWidget() {
         super("kuudra_direction",
@@ -27,7 +32,7 @@ public class KuudraDirectionWidget extends HudWidget {
         setEnabledSupplier(() -> PhaseFourConfig.kuudraDirectionAlert);
         setVisibilityCondition(() -> {
             var phase = KuudraStateManager.get().phase();
-            return phase == KuudraPhase.BOSS;
+            return phase == KuudraPhase.SKIP || phase == KuudraPhase.BOSS;
         });
 
         setExampleLines(HudLine.of("§a§lFRONT"));
@@ -35,16 +40,36 @@ public class KuudraDirectionWidget extends HudWidget {
 
     @Override
     protected void onActivate() {
+        directionTicksRemaining = 0;
+
         clearLines();
         addLines(directionLine);
 
         subscribe(KuudraDirectionChangeEvent.class, this::onDirectionChange);
+        subscribe(ClientTickEvent.class, this::onTick);
+    }
+
+    @Override
+    protected void onDeactivate() {
+        directionTicksRemaining = 0;
     }
 
     private void onDirectionChange(@NotNull KuudraDirectionChangeEvent event) {
         var newDirection = event.newDirection();
 
         directionLine.text(newDirection.getFormattedName());
+        directionTicksRemaining = DISPLAY_TICKS;
         markDimensionsDirty();
+    }
+
+    private void onTick(@NotNull ClientTickEvent event) {
+        if (!event.isInGame()) return;
+
+        if (directionTicksRemaining > 0) {
+            directionTicksRemaining--;
+            if (directionTicksRemaining == 0) {
+                markDimensionsDirty();
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Reduce spurious Kuudra direction change events by requiring a stable reading over multiple ticks and enforcing an event cooldown. 
- Ensure detection only runs in relevant phases (`SKIP` and `BOSS`) and handle cases where the boss entity may not be directly available. 
- Make the on-screen direction indicator transient so it does not persist indefinitely and only shows while relevant.

### Description

- Added debounce and cooldown logic to `DirectionDetector` including `DIRECTION_CONFIRM_TICKS`, `DIRECTION_EVENT_COOLDOWN_TICKS`, `candidateDirection`, `candidateStartTick`, and `lastDirectionEventTick`, and helper methods `isCandidateStable`, `isOutsideCooldown`, and `clearCandidate`. 
- Updated detection flow to use a resolved `kuudraEntity` (falling back to `KuudraLocationUtil.findKuudra()`), require stable `rawDirection` for `DIRECTION_CONFIRM_TICKS` ticks before firing a `KuudraDirectionChangeEvent`, and prevent repeated events during cooldown. 
- Updated `reset()` to clear candidate state and cooldown tracking. 
- Modified `KuudraDirectionWidget` to show in both `SKIP` and `BOSS` phases, add a timed display controlled by `DISPLAY_TICKS` and `directionTicksRemaining`, and subscribe to `ClientTickEvent` to decrement the display timer and hide the line when time expires. 
- Ensured the widget initializes and clears `directionTicksRemaining` on activation/deactivation and uses `HudLine.showWhen` to conditionally render the direction text.

### Testing

- Ran the project test suite with `./gradlew test`, and all tests completed successfully. 
- Built the client module with `./gradlew :client:jar` to validate compilation, and the build succeeded. 
- Verified no new automated tests were added for the detector or widget in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c0ea39c20832a8551b110ce3e1d5a)