### PR TITLE
perf(hud): batch config saves added, removing redundant writes.

### DIFF
--- a/src/client/java/net/iqaddons/mod/hud/HudManager.java
+++ b/src/client/java/net/iqaddons/mod/hud/HudManager.java
@@ -164,8 +164,9 @@ public final class HudManager {
 
     public void saveConfig() {
         for (HudWidget widget : widgets) {
-            configManager.saveFromWidget(widget, true);
+            configManager.saveFromWidget(widget);
         }
+        
         configManager.saveAsync();
     }
 

--- a/src/client/java/net/iqaddons/mod/hud/HudManager.java
+++ b/src/client/java/net/iqaddons/mod/hud/HudManager.java
@@ -164,8 +164,9 @@ public final class HudManager {
 
     public void saveConfig() {
         for (HudWidget widget : widgets) {
-            configManager.saveFromWidget(widget);
+            configManager.saveFromWidget(widget, true);
         }
+        configManager.saveAsync();
     }
 
     public boolean handleClick(double mouseX, double mouseY, int button) {

--- a/src/client/java/net/iqaddons/mod/hud/config/HudConfigManager.java
+++ b/src/client/java/net/iqaddons/mod/hud/config/HudConfigManager.java
@@ -119,6 +119,10 @@ public class HudConfigManager {
         saveAsync();
     }
 
+    public void setConfigSilent(@NotNull HudElementConfig config) {
+        configCache.put(config.id(), config.validated());
+    }
+
     public void updatePosition(@NotNull String elementId, float x, float y) {
         HudElementConfig existing = configCache.get(elementId);
         if (existing != null) {
@@ -145,9 +149,14 @@ public class HudConfigManager {
         }
     }
 
-    public void saveFromWidget(@NotNull HudWidget widget) {
+    public void saveFromWidget(@NotNull HudWidget widget, boolean silent) {
         HudElementConfig config = HudElementConfig.fromWidget(widget);
-        setConfig(config);
+
+        if (silent) {
+            setConfigSilent(config);
+        } else {
+            setConfig(config);
+        }
     }
 
     public boolean hasConfig(@NotNull String elementId) {

--- a/src/client/java/net/iqaddons/mod/hud/config/HudConfigManager.java
+++ b/src/client/java/net/iqaddons/mod/hud/config/HudConfigManager.java
@@ -116,11 +116,6 @@ public class HudConfigManager {
 
     public void setConfig(@NotNull HudElementConfig config) {
         configCache.put(config.id(), config.validated());
-        saveAsync();
-    }
-
-    public void setConfigSilent(@NotNull HudElementConfig config) {
-        configCache.put(config.id(), config.validated());
     }
 
     public void updatePosition(@NotNull String elementId, float x, float y) {
@@ -149,14 +144,9 @@ public class HudConfigManager {
         }
     }
 
-    public void saveFromWidget(@NotNull HudWidget widget, boolean silent) {
+    public void saveFromWidget(@NotNull HudWidget widget) {
         HudElementConfig config = HudElementConfig.fromWidget(widget);
-
-        if (silent) {
-            setConfigSilent(config);
-        } else {
-            setConfig(config);
-        }
+        setConfig(config);
     }
 
     public boolean hasConfig(@NotNull String elementId) {


### PR DESCRIPTION
# Summary
This PR reduces redundant async config saves during hud updates.
Currently, saves trigger one async write per widget, this change, batches config updates together for 1 disk write.

## Changes

- added silent config update method
- updated hud save flow to batch updates
- force only one saveAsync() call per (bulk) save.

Closes #9 