### PR TITLE
Add Ender Pearl trajectory overlay with pile placement detection and alert

### DIFF
--- a/src/client/java/net/iqaddons/mod/config/categories/PhaseOneConfig.java
+++ b/src/client/java/net/iqaddons/mod/config/categories/PhaseOneConfig.java
@@ -208,6 +208,37 @@ public class PhaseOneConfig {
     @Comment("Makes pearl waypoints move up or down based on your position so the marker stays more accurate while doing supplies.")
     public static boolean dynamicPearlWaypoints = true;
 
+    @ConfigEntry(
+            id = "pearlTrajectoryLine",
+            translation = "Pearl Trajectory Line"
+    )
+    @Comment("Render a smooth real-time line showing where your Ender Pearl will land.")
+    public static boolean pearlTrajectoryLine = true;
+
+    @ConfigEntry(
+            id = "pearlTrajectoryLineColor",
+            translation = "Pearl Trajectory Line Color"
+    )
+    @ConfigOption.Color(alpha = true)
+    @Comment("Color used for the Ender Pearl trajectory overlay line.")
+    public static int pearlTrajectoryLineColor = new Color(0, 255, 170, 180).getRGB();
+
+    @ConfigEntry(
+            id = "pearlTrajectoryPlacementAlert",
+            translation = "Pearl Placement Guarantee Alert"
+    )
+    @Comment("Show a subtle subtitle alert when your trajectory is aligned with a valid pile.")
+    public static boolean pearlTrajectoryPlacementAlert = true;
+
+    @ConfigEntry(
+            id = "pearlTrajectoryPileTolerance",
+            translation = "Pearl Pile Tolerance"
+    )
+    @ConfigOption.Range(min = 0.1, max = 2.0)
+    @ConfigOption.Slider
+    @Comment("Horizontal X/Z tolerance used to consider trajectory landing as valid for a pile.")
+    public static double pearlTrajectoryPileTolerance = 0.7;
+
 
     @ConfigOption.Separator("Pile Waypoints")
 

--- a/src/client/java/net/iqaddons/mod/events/impl/WorldRenderEvent.java
+++ b/src/client/java/net/iqaddons/mod/events/impl/WorldRenderEvent.java
@@ -78,6 +78,10 @@ public record WorldRenderEvent(
         WorldRenderUtils.drawTracer(matrices, consumer, camera, pos, color);
     }
 
+    public void drawLine(Vec3d start, Vec3d end, boolean throughWalls, RenderColor color) {
+        WorldRenderUtils.drawLine(matrices, consumer, camera, start, end, throughWalls, color);
+    }
+
     public void drawHitbox(Entity entity, boolean troughWalls, RenderColor color) {
         WorldRenderUtils.drawHitBox(matrices, consumer, camera, entity, tickCounter, troughWalls, color);
     }
@@ -86,5 +90,4 @@ public record WorldRenderEvent(
         WorldRenderUtils.drawStyledHitBox(matrices, consumer, camera, entity, tickCounter, throughWalls, color, style);
     }
 }
-
 

--- a/src/client/java/net/iqaddons/mod/features/kuudra/waypoints/PearlTrajectoryFeature.java
+++ b/src/client/java/net/iqaddons/mod/features/kuudra/waypoints/PearlTrajectoryFeature.java
@@ -1,0 +1,164 @@
+package net.iqaddons.mod.features.kuudra.waypoints;
+
+import net.iqaddons.mod.config.categories.PhaseOneConfig;
+import net.iqaddons.mod.config.loader.PileConfigLoader;
+import net.iqaddons.mod.events.impl.ClientTickEvent;
+import net.iqaddons.mod.events.impl.WorldRenderEvent;
+import net.iqaddons.mod.features.KuudraFeature;
+import net.iqaddons.mod.model.kuudra.KuudraPhase;
+import net.iqaddons.mod.model.spot.PileLocation;
+import net.iqaddons.mod.utils.MessageUtil;
+import net.iqaddons.mod.utils.render.RenderColor;
+import net.minecraft.block.FluidBlock;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.EnderPearlItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.RaycastContext;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PearlTrajectoryFeature extends KuudraFeature {
+
+    private static final int MAX_SIMULATION_STEPS = 200;
+    private static final double INITIAL_SPEED = 1.5;
+    private static final double DRAG_AIR = 0.99;
+    private static final double DRAG_WATER = 0.8;
+    private static final double GRAVITY = 0.03;
+
+    private static final long ALERT_COOLDOWN_MS = 1200L;
+
+    private final List<Vec3d> points = new ArrayList<>();
+
+    private Vec3d landingPoint;
+    private boolean guaranteedPlacement;
+    private long lastAlertAtMs;
+
+    public PearlTrajectoryFeature() {
+        super(
+                "pearlTrajectory",
+                "Pearl Trajectory",
+                () -> PhaseOneConfig.pearlTrajectoryLine,
+                KuudraPhase.SUPPLIES
+        );
+
+        PileConfigLoader.get().load();
+    }
+
+    @Override
+    protected void onKuudraActivate() {
+        subscribe(ClientTickEvent.class, this::onTick);
+        subscribe(WorldRenderEvent.class, this::onWorldRender);
+    }
+
+    @Override
+    protected void onKuudraDeactivate() {
+        points.clear();
+        landingPoint = null;
+        guaranteedPlacement = false;
+    }
+
+    private void onTick(@NotNull ClientTickEvent event) {
+        if (!event.isInGame()) return;
+
+        boolean wasGuaranteed = guaranteedPlacement;
+        updateTrajectory();
+
+        if (!PhaseOneConfig.pearlTrajectoryPlacementAlert) return;
+        if (!guaranteedPlacement || wasGuaranteed) return;
+
+        long now = System.currentTimeMillis();
+        if (now - lastAlertAtMs < ALERT_COOLDOWN_MS) return;
+
+        lastAlertAtMs = now;
+        MessageUtil.showTitle("", "&a%SUPPLY Guaranteed Placed", 0, 18, 6);
+    }
+
+    private void onWorldRender(@NotNull WorldRenderEvent event) {
+        if (points.size() < 2) return;
+
+        RenderColor lineColor = RenderColor.fromArgb(PhaseOneConfig.pearlTrajectoryLineColor);
+        for (int i = 1; i < points.size(); i++) {
+            Vec3d start = points.get(i - 1);
+            Vec3d end = points.get(i);
+            event.drawLine(start, end, true, lineColor);
+        }
+    }
+
+    private void updateTrajectory() {
+        points.clear();
+        landingPoint = null;
+        guaranteedPlacement = false;
+
+        PlayerEntity player = mc.player;
+        if (player == null || mc.world == null) return;
+
+        if (!isHoldingPearl(player)) return;
+
+        Vec3d pos = player.getEyePos().add(player.getRotationVec(1.0f).multiply(0.16));
+        Vec3d velocity = player.getRotationVec(1.0f).normalize().multiply(INITIAL_SPEED);
+
+        points.add(pos);
+
+        for (int i = 0; i < MAX_SIMULATION_STEPS; i++) {
+            Vec3d nextPos = pos.add(velocity);
+
+            BlockHitResult hit = mc.world.raycast(new RaycastContext(
+                    pos,
+                    nextPos,
+                    RaycastContext.ShapeType.COLLIDER,
+                    RaycastContext.FluidHandling.NONE,
+                    player
+            ));
+
+            if (hit.getType() != HitResult.Type.MISS) {
+                Vec3d impactPos = hit.getPos();
+                points.add(impactPos);
+                landingPoint = impactPos;
+                break;
+            }
+
+            points.add(nextPos);
+
+            BlockPos nextBlockPos = BlockPos.ofFloored(nextPos);
+            boolean inWater = mc.world.getBlockState(nextBlockPos).getBlock() instanceof FluidBlock;
+            velocity = velocity.multiply(inWater ? DRAG_WATER : DRAG_AIR).subtract(0, GRAVITY, 0);
+            pos = nextPos;
+
+            if (pos.y < mc.world.getBottomY() - 4) break;
+        }
+
+        if (landingPoint != null) {
+            guaranteedPlacement = matchesAnyPile(landingPoint);
+        }
+    }
+
+    private boolean matchesAnyPile(@NotNull Vec3d impact) {
+        double toleranceSq = PhaseOneConfig.pearlTrajectoryPileTolerance * PhaseOneConfig.pearlTrajectoryPileTolerance;
+
+        for (PileLocation pile : PileConfigLoader.get().getCached()) {
+            Vec3d pilePos = pile.position();
+            double dx = impact.x - pilePos.x;
+            double dz = impact.z - pilePos.z;
+
+            if ((dx * dx) + (dz * dz) <= toleranceSq) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isHoldingPearl(@NotNull PlayerEntity player) {
+        ItemStack main = player.getMainHandStack();
+        if (main.getItem() instanceof EnderPearlItem) return true;
+
+        ItemStack off = player.getOffHandStack();
+        return off.getItem() instanceof EnderPearlItem;
+    }
+}

--- a/src/client/java/net/iqaddons/mod/lifecycle/modules/FeatureModule.java
+++ b/src/client/java/net/iqaddons/mod/lifecycle/modules/FeatureModule.java
@@ -24,7 +24,7 @@ public class FeatureModule implements LifecycleComponent {
         );
 
         features.register(
-                new PearlWaypointFeature(), new SupplyWaypointsFeature(), new PileWaypointsFeature(),
+                new PearlWaypointFeature(), new PearlTrajectoryFeature(), new SupplyWaypointsFeature(), new PileWaypointsFeature(),
                 new NoPreAlertFeature(), new CratePriorityFeature(), new SecondSupplyAlertFeature(), new CustomSupplyMessageFeature(),
                 new ElleHighlightFeature(), new FreshAlertFeature(), new KuudraHitboxFeature(),
                 new RendDamageAlertFeature(), new BuildWaypointsFeature(), new StunWaypointsFeature(),

--- a/src/client/java/net/iqaddons/mod/utils/render/WorldRenderUtils.java
+++ b/src/client/java/net/iqaddons/mod/utils/render/WorldRenderUtils.java
@@ -239,6 +239,31 @@ public class WorldRenderUtils {
         matrices.pop();
     }
 
+    public static void drawLine(
+            @NotNull MatrixStack matrices, VertexConsumerProvider.@NotNull Immediate consumer,
+            @NotNull Camera camera, @NotNull Vec3d start, @NotNull Vec3d end,
+            boolean throughWalls, @NotNull RenderColor color
+    ) {
+        matrices.push();
+        Vec3d camPos = camera.getPos();
+        matrices.translate(-camPos.getX(), -camPos.getY(), -camPos.getZ());
+
+        MatrixStack.Entry entry = matrices.peek();
+        VertexConsumer buffer = consumer.getBuffer(throughWalls ? Layers.GuiLine : Layers.BoxOutline);
+
+        Vector3f normal = end.toVector3f()
+                .sub((float) start.getX(), (float) start.getY(), (float) start.getZ())
+                .normalize(new Vector3f(1.0f, 1.0f, 1.0f));
+
+        buffer.vertex(entry, (float) start.getX(), (float) start.getY(), (float) start.getZ())
+                .color(color.r, color.g, color.b, color.a)
+                .normal(entry, normal);
+        buffer.vertex(entry, (float) end.getX(), (float) end.getY(), (float) end.getZ())
+                .color(color.r, color.g, color.b, color.a)
+                .normal(entry, normal);
+        matrices.pop();
+    }
+
     public static void drawHitBox(
             @NotNull MatrixStack matrices, VertexConsumerProvider.Immediate consumer,
             @NotNull Camera camera, Entity entity, @NotNull RenderTickCounter tickCounter,

--- a/src/client/resources/default-config/iq/pile_locations.json
+++ b/src/client/resources/default-config/iq/pile_locations.json
@@ -17,34 +17,33 @@
   "piles": [
     {
       "name": "Shop",
-      "position": [-98, 78.125, -112.9375],
+      "position": [-98.5, 78.4, -113.5],
       "noPreValue": 7
     },
     {
       "name": "Triangle",
-      "position": [-94, 78.125, -106],
+      "position": [-94.5, 78.4, -106.5],
       "noPreValue": 6
     },
     {
       "name": "Equals",
-      "position": [-106, 78.125, -99.0625],
+      "position": [-106.5, 78.4, -99.5],
       "noPreValue": 5
     },
     {
       "name": "Slash",
-      "position": [-98, 78.125, -99.0625],
+      "position": [-98.5, 78.4, -99.5],
       "noPreValue": 4
     },
     {
       "name": "X Cannon",
-      "position": [-110, 78.125, -106],
+      "position": [-110.5, 78.4, -106.5],
       "noPreValue": 2
     },
     {
       "name": "X",
-      "position": [-106, 78.125, -112.9375],
+      "position": [-106.5, 78.4, -113.5],
       "noPreValue": 1
     }
   ]
 }
-


### PR DESCRIPTION
### Motivation
- Provide a realtime visual predictor for Ender Pearl throws so players can accurately see where a pearl will land and know when it aligns with a known pile waypoint.
- Offer a simple X/Z-only pile matching check with a small configurable tolerance and a subtle on-screen alert to guarantee placement when aligned.

### Description
- Added a new feature `PearlTrajectoryFeature` that simulates Ender Pearl flight and renders a smooth world-space trajectory line while holding a pearl during the Kuudra Supplies phase.
- Implemented pile landing detection using X/Z distance only and a configurable tolerance, and show a configurable subtitle alert (`%SUPPLY Guaranteed Placed`) when a trajectory matches a pile.
- Added config options to `PhaseOneConfig` (`pearlTrajectoryLine`, `pearlTrajectoryLineColor`, `pearlTrajectoryPlacementAlert`, `pearlTrajectoryPileTolerance`) to control the feature and its appearance.
- Extended rendering utilities with a reusable `drawLine` API in `WorldRenderUtils` and exposed it via `WorldRenderEvent.drawLine`, and registered the feature in the feature lifecycle so it activates during Kuudra supplies.
- Updated default `pile_locations.json` coordinates to the provided reference positions.

### Testing
- Attempted to run `./gradlew compileJava compileClientJava -x test` to compile the client; the build could not complete in this environment because the Gradle wrapper download was blocked by a proxy (`HTTP/1.1 403 Forbidden`).
- No other automated tests were run in this environment (compilation was not possible due to the network/proxy restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ce12f098832a9e36e7a7e1a89d93)